### PR TITLE
feat: Filter result to released builds by default

### DIFF
--- a/GetPerfStats/index.js
+++ b/GetPerfStats/index.js
@@ -5,7 +5,7 @@ const mongodbUri = process.env['MONGODB_URI']
 const mongodbUser = process.env['MONGODB_USER']
 const mongodbPass = process.env['MONGODB_PASS']
 const itemLimit = 250 // number of items returned when public-only filter is off
-const publicItemLimit = 50 // number of items returned when public-only filter is on (default)
+const publicItemLimit = 30 // number of items returned when public-only filter is on (default)
 
 /**
  * Returns list of perf results on master branch, sorted by build number desc

--- a/GetPerfStats/index.js
+++ b/GetPerfStats/index.js
@@ -1,9 +1,11 @@
 const mongodb = require('mongodb')
-const config = require('../Shared/config')
 
 const mongodbUri = process.env['MONGODB_URI']
 const mongodbUser = process.env['MONGODB_USER']
 const mongodbPass = process.env['MONGODB_PASS']
+const mongodbDatabase = process.env['MONGODB_DATABASE']
+const mongodbCollection = process.env['MONGODB_COLLECTION']
+
 const itemLimit = 250 // number of items returned when public-only filter is off
 const publicItemLimit = 30 // number of items returned when public-only filter is on (default)
 
@@ -55,8 +57,8 @@ module.exports = async function(context, req) {
 
   try {
     const data = await mongoClient
-      .db(config.database.db)
-      .collection(config.database.collection)
+      .db(mongodbDatabase)
+      .collection(mongodbCollection)
       .find(query)
       .project(project)
       .sort([['_id', -1]]) // build === _id and _id is indexed

--- a/SaveStats/index.js
+++ b/SaveStats/index.js
@@ -17,6 +17,8 @@ module.exports = async function(context, req) {
   const mongodbUri = process.env['MONGODB_URI']
   const mongodbUser = process.env['MONGODB_USER']
   const mongodbPass = process.env['MONGODB_PASS']
+  const mongodbDatabase = process.env['MONGODB_DATABASE']
+  const mongodbCollection = process.env['MONGODB_COLLECTION']
 
   context.log('SaveStats, DB:', mongodbUri)
 
@@ -52,8 +54,8 @@ module.exports = async function(context, req) {
   document.ts = new Date(document.ts)
   try {
     await mongoClient
-      .db('stardust')
-      .collection('stats')
+      .db(mongodbDatabase)
+      .collection(mongodbCollection)
       .insertOne(document)
     context.log('document inserted')
   } catch (err) {

--- a/Shared/config.js
+++ b/Shared/config.js
@@ -1,8 +1,5 @@
 const config = {
-  database: {
-    db: 'stardust',
-    collection: 'stats',
-  },
+  // empty
 }
 
 module.exports = config


### PR DESCRIPTION
`GetPerfStats` now returns 50 tagged (=released) builds by default.
When `withPrivateBuilds` query parameter is used, it returns last 250 builds (previous behavior).